### PR TITLE
fix JSONDecodeError: Invalid \X escape sequence u'\\'

### DIFF
--- a/uwsgitop
+++ b/uwsgitop
@@ -137,7 +137,7 @@ while True:
     except:
         raise Exception("unable to get uWSGI statistics")
 
-    dd = json.loads(js)
+    dd = json.loads(js.replace('\\', '\\\\'))
 
 
     


### PR DESCRIPTION
I frequently see this error due to specific request contents in the stats server output. I'm connecting to a socket. This fix works for me, but I'm not certain how to make sure it's the correct solution.
