### PR TITLE
Added striping of HTTP_COOKIE header

### DIFF
--- a/uwsgitop
+++ b/uwsgitop
@@ -11,6 +11,7 @@ import atexit
 import sys
 import traceback
 from collections import defaultdict
+import re
 
 need_reset = True
 screen = None
@@ -137,6 +138,7 @@ while True:
     except:
         raise Exception("unable to get uWSGI statistics")
 
+    js = re.sub(r'"HTTP_COOKIE=[^"]*"', '""', js)
     dd = json.loads(js)
 
 


### PR DESCRIPTION
uWSGI stats server returns environment variables inside "cores" list. That list contains HTTP_COOKIE header. That header can contain octal-escaped characters and that will raise ValueError during json parsing. I think the simplest way is just to strip that header at all since it doesn't used for any data.

Example of traceback:

<pre>
Traceback (most recent call last):
  File "/usr/local/bin/uwsgitop", line 114, in <module>
    dd = json.loads(js)
  File "/usr/lib/python2.7/json/__init__.py", line 326, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 365, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 381, in raw_decode
    obj, end = self.scan_once(s, idx)
ValueError: Invalid \escape: line 243 column 486 (char 4854)
</pre>
