### PR TITLE
Fixed interpreter

### DIFF
--- a/uwsgitop
+++ b/uwsgitop
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python
 
 import socket
 try:


### PR DESCRIPTION
Diff should explain everything…

For now trying to start uwsgitop results with:
`-bash: /root/uwsgitop: python: bad interpreter: No such file or directory`
