### PR TITLE
Fix for python 3 support

### DIFF
--- a/uwsgitop
+++ b/uwsgitop
@@ -142,7 +142,7 @@ while True:
             if len(data) < 1:
                 break
             js += data.decode('utf8')
-    except IOError, e:
+    except IOError as e:
         if e.errno != errno.EINTR:
             raise
         continue


### PR DESCRIPTION
Fixes the syntax error on line 145 when using Python 3 as specified in [pep-3110](https://www.python.org/dev/peps/pep-3110/).

```
File "uwsgitop", line 145
    except IOError, e:
                  ^
SyntaxError: invalid syntax
```

