### PR TITLE
Fix a crash when uwsgi sends back empty messages

### DIFF
--- a/uwsgitop
+++ b/uwsgitop
@@ -178,7 +178,10 @@ def main():
         except:
             raise Exception("unable to get uWSGI statistics")
 
-        dd = json.loads(js)
+        try:
+            dd = json.loads(js)
+        except json.JSONDecodeError:
+            continue
 
         uversion = ''
         if 'version' in dd:


### PR DESCRIPTION
- The socket can sometimes return an empty string, so catch invalid json strings and continue on to the next read. This allows uwsgitop to keep running when the stats socket might return an empty string.